### PR TITLE
adds handling for suspensions (as opposed to unenrollments)

### DIFF
--- a/db/events.php
+++ b/db/events.php
@@ -34,4 +34,9 @@ $observers = array(
         'eventname' => '\core\event\user_enrolment_deleted',
         'callback'  => '\local_metasync\observers::user_enrolment_deleted',
     ),
+
+    array(
+        'eventname' => '\core\event\user_enrolment_updated',
+        'callback'  => '\local_metasync\observers::user_enrolment_updated',
+    ),
 );


### PR DESCRIPTION
- Addition to an automated group in a metacourse should occur only when the enrollment in the child course is active.
- We need to listen not only for enrollment adds and removals but also for updates. When an update changes the status of a child course enrollment, we need to add or remove the user from the automated group in the metacourse.
- The cli sync should add only active child course enrollments to the metacourse groups.
- The cli sync should clean up errors where suspended users are in an automated group.
